### PR TITLE
Fix example using epic_id key

### DIFF
--- a/EpicGames/AccountService/PublicKey.md
+++ b/EpicGames/AccountService/PublicKey.md
@@ -6,7 +6,7 @@ Auth Required: No
 
 ## Path Parameters
 
-`thumbprint`: The Public or Private Key Thumbprint, e.g. 'WMS7EnkIGpcH9DGZsv2WcY9xsuFnZCtxZjj4Ahb-\_8E' ('kid' from eg1 JWT Header)
+`thumbprint`: The Public or Private Key Thumbprint, e.g. `g__VKjSSmqJ0xZj1RYkLGKQ7dnHiM9MLhFVwKPySDB4` (`kid` from eg1 JWT Header) or `WMS7EnkIGpcH9DGZsv2WcY9xsuFnZCtxZjj4Ahb-_8E` (`kid` from epic_id JWT Header)
 
 ---
 
@@ -16,7 +16,7 @@ _Example Response_
 {
   "kty": "RSA",
   "e": "AQAB",
-  "kid": "WMS7EnkIGpcH9DGZsv2WcY9xsuFnZCtxZjj4Ahb-_8E",
-  "n": "l6XI48ujknQQlsJgpGXg4l2i_DuUxuG2GXTzkOG7UtX4MqkVBCfW1t1JIIc8q0kCInC2oBwhC599ZCmd-cOi0kS7Aquv68fjERIRK9oCUnF_lJg296jV8xcalFY0FOWX--qX3xGKL33VjJBMIrIu7ETjj06s-v4li22CnHmu2lDkrp_FPTVzFscn-XRIojqIFb7pKRFPt27m12FNE_Rd9bqlVCkvMNuE7VTpTOrSfKk5B01M5IuXKXk0pTAWnelqaD9bHjAExe2I_183lp_uFhNN4hLTjOojxl-dK8Jy2OCPEAsg5rs9Lwttp3zZ--y0sM7UttN2dE0w3F2f352MNQ"
+  "kid": "g__VKjSSmqJ0xZj1RYkLGKQ7dnHiM9MLhFVwKPySDB4",
+  "n": "2QqXCndTrbOC8YqRcZPhixXFrGgL5cUOWP7IJgroYIgQ4JWIrXIY89zs0QvmdDdwHvp_CKRnfin6nsNhYKzVCghDuZ5Es5Zn7YbIzU6TGhYmQ0xE84AIgTh5Z-1j4K1aFxGLGajftbIfltwKHXLEwGd9Amylb0_Nd_KlQvmYR_3Cu85MKiQCzpvyP0Ex07WCL9rDeo4rct6jztrE31PrrM7KXBY9dV_OrQWsq72thsGrCYMx-vcMwXFZu-wtWzCJH1LwWuMW6yOcu-ipndYpLTKtr0S57izs6sSYS3nj2xJGWp_rLK7Xrqb6X8raFuExMG3kgb17scLqv5v51cvYZ3Aqw9Q0RGkeTejoku7G970EDxC-abrgVfIHePBklFcFviyNBKE0IxWZjt1MQENRh9lJOPXP_0WAnm3NvSDSVqSzBYxggPA_dtUUo6IZ-m-cX3NVyeBEkkfZXRgWhXfW7F9GZ9SvpvXdjweBCUO9m0mwPzFXJwt1FGtJYnkSd5M00D3srX2FdulPfnOZhXSSSmKSEgpetq0UGu4JiVAZmPELo9k5jrzA_9kuyRC_AnIIcKSZH1sTVacIxW0fsufxJbpnqWs3jGGPQXlBHteAr8PZ3PQ0REjorXgdMICuv_dSN_HrGATthnqEaOnF3Nk5aNBhVAFHpe-j7q8nCjw8gbc"
 }
 ```


### PR DESCRIPTION
`WMS7EnkIGpcH9DGZsv2WcY9xsuFnZCtxZjj4Ahb-_8E` is actually the key used to sign epic_id tokens, not eg1 tokens. I updated the example to contain both keys.