### PR TITLE
Add allowCountries param

### DIFF
--- a/EpicGamesStore/FreePromos.md
+++ b/EpicGamesStore/FreePromos.md
@@ -7,7 +7,7 @@ Auth Required: No
 ## Query Parameters
 
 `locale`: The requested Language, defaults to english <br/>
-`country`: Determines the price and which currency is shown
+`country`: Determines the price and which currency is shown<br/>
 `allowCountries`: Show all promos available in the requested Countries
 
 > All Query Params are optional and there may be more

--- a/EpicGamesStore/FreePromos.md
+++ b/EpicGamesStore/FreePromos.md
@@ -7,7 +7,8 @@ Auth Required: No
 ## Query Parameters
 
 `locale`: The requested Language, defaults to english <br/>
-`country`: Show all promos available in the requested Country
+`country`: Show all promos available in the requested Country. Also determines the currency used.
+`allowCountries`: Show all promos available in the requested Countries
 
 > All Query Params are optional and there may be more
 

--- a/EpicGamesStore/FreePromos.md
+++ b/EpicGamesStore/FreePromos.md
@@ -7,7 +7,7 @@ Auth Required: No
 ## Query Parameters
 
 `locale`: The requested Language, defaults to english <br/>
-`country`: Show all promos available in the requested Country. Also determines the currency used.
+`country`: Determines the price and which currency is shown
 `allowCountries`: Show all promos available in the requested Countries
 
 > All Query Params are optional and there may be more


### PR DESCRIPTION
## PR Checklist

- [x] I have properly named the PR
- [x] I have described why this change should be merged (why is this change useful/good)
- [x] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Change Description

<!-- Here you should provide a description, why this change(s) were made and why these should be merged -->

There was a missing parameter. I'm unsure exactly what the parameter does, but it seems like both allowCountries and country affect which games are shown. `country` also affects which currency is used.

So example calls that showcase the differences:
| URL | Note |
| ----- | ----- |
| https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=NO&allowCountries=NO | Currency is NOK and Ghostwire is shown since it is available in Norway |
| https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=NO&allowCountries=RU | Currency is also NOK, but some games (for example Ghostwire) aren't shown since the allowCountries is Russia. |
| https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=RU&allowCountries=RU | Currency is RUB and Ghostwire isn't shown |
| https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=RU&allowCountries=NO | Here the currency is RUB but Ghostwire is shown, since Ghostwire is available in Norway |

