### PR TITLE
Fix QueryPublicProfile Hyperlink in FN-Service Profile Readme.

### DIFF
--- a/EpicGames/FN-Service/Game/Profile/README.md
+++ b/EpicGames/FN-Service/Game/Profile/README.md
@@ -45,5 +45,5 @@
 | ProfileId        | Description                                                                                           |
 | ---------------- | ----------------------------------------------------------------------------------------------------- |
 | client           | The one you usually use                                                                               |
-| public           | Only used for [QueryPublicProfile](./operations/QueryPublicProfile.md)                                |
+| public           | Only used for [QueryPublicProfile](./Operations/QueryPublicProfile.md)                                |
 | dedicated_server | Server Route, requires `fortnite:fortnite_role:dedicated_server ALL` Permission (aka you cant use it) |


### PR DESCRIPTION
## PR Checklist

- [x] I have properly named the PR
- [x] I have described why this change should be merged (why is this change useful/good)
- [x] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Readme in FN-Service MCP Profile Fix

The previous hyperlink to QueryPublicProfile doesn't work due to `/operations` not being capitalized.
