### PR TITLE
dataOmissionGroup query addition,

### DIFF
--- a/EpicGames/FN-Service/Game/Profile/README.md
+++ b/EpicGames/FN-Service/Game/Profile/README.md
@@ -12,6 +12,7 @@
 | --------- | ----------- | ------------- |
 | profileId | {profileId} | common_core   |
 | rvn       | -1          | -1            |
+| dataOmissionGroup       | {dataOmissionGroup}          | Locker            |
 
 **NOTE**: if its a "DedicatedServer ONLY" operation you cant use it
 


### PR DESCRIPTION
dataOmissionGroup

## PR Checklist

- [x] I have properly named the PR
- [x] I have described why this change should be merged (why is this change useful/good)
    -    It's used on fortnite requests, and there is no sign of documentation on this parameter here.

- [x] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Change Description

This should be merged as its a required parameter in urls that Fortnite has started to use, an example of this being used is in QueryProfile where the dataOmissionGroup parameter can be seen several times in the url: `/fortnite/api/game/v2/profile/bf2a486b68af4a35b8ca0b77a51d6471/client/QueryProfile?profileId=athena&rvn=-1&dataOmissionGroup=Locker&dataOmissionGroup=banner-token&dataOmissionGroup=conditional-action&dataOmissionGroup=cosmetic-variant-token&dataOmissionGroup=quest`
