### PR TITLE
Add switch 2

### DIFF
--- a/EpicGames/LauncherService/README.md
+++ b/EpicGames/LauncherService/README.md
@@ -23,4 +23,4 @@ Recommended Hosts:
 
 # Data
 
-`platform`: Windows, Android, IOS, XSX, PS4, PS5, Switch
+`platform`: Windows, Android, IOS, XSX, PS4, PS5, Switch,Switch2


### PR DESCRIPTION
Switch2 has been added to the host, `platform`, of the Launcher service.
