### PR TITLE
Add External Auth Response to Continuation Token lookup endpoint

### DIFF
--- a/EpicGames/AccountService/Authentication/ContinuationToken/Info.md
+++ b/EpicGames/AccountService/Authentication/ContinuationToken/Info.md
@@ -8,7 +8,7 @@ Auth Required: Yes (`account:oauth:continuationToken READ`)
 
 `continuationToken`: 16 Bytes in hex token
 
-_Example Response_
+_Example Response (Any Corrective Action)_
 
 ```json
 {
@@ -22,5 +22,22 @@ _Example Response_
   "correctiveAction": "SCOPE_CONSENT",
   "ageGateRequired": true,
   "acr": "urn:epic:loa:aal1"
+}
+```
+
+_Example Response (With `EXTERNAL_AUTH_NOT_FOUND` corrective action)_
+
+```json
+{
+    "tokenId": "cf98b44dfe4641778cca075bc1319ccb",
+    "shortTokenId": "cb5133c6",
+    "clientId": "xyza7891p5D7s9R6Gm6moTHWGloerp7B",
+    "scopes": [],
+    "platformType": "nintendo",
+    "externalAuthId": "lp1_00QIU7B6WPKJJXM56TXIDBVY2FPE",
+    "externalAuthEnv": "lp1",
+    "correctiveAction": "EXTERNAL_AUTH_NOT_FOUND",
+    "ageGateRequired": true,
+    "acr": "urn:epic:loa:aal1"
 }
 ```


### PR DESCRIPTION
## PR Checklist

- [ ] I have properly named the PR
- [ ] I have described why this change should be merged (why is this change useful/good)
- [ ] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Change Description

<!-- Here you should provide a description, why this change(s) were made and why these should be merged -->
