### PR TITLE
Fix ClaimCollectionBookRewards payload

### DIFF
--- a/EpicGames/FN-Service/Game/Profile/Operations/ClaimCollectionBookRewards.md
+++ b/EpicGames/FN-Service/Game/Profile/Operations/ClaimCollectionBookRewards.md
@@ -7,7 +7,7 @@
 
 ```js
 {
-    "requiredXp": 3613250, // XP for the Collection Book Level
+    "requiredXP": 3613250, // XP for the Collection Book Level
     "selectedRewardIndex": -1 // If there are multiple rewards possible select the index of the reward
 }
 ```


### PR DESCRIPTION
requiredXP requires a capital P, requiredXp is not accepted