### PR TITLE
Launcher Service - Added selectiveDownload to manifest example response.

### DIFF
--- a/EpicGames/LauncherService/Assets/V2/GetItemBuild.md
+++ b/EpicGames/LauncherService/Assets/V2/GetItemBuild.md
@@ -22,23 +22,36 @@ _Example Response (shortened)_
     {
       "appName": "Fortnite",
       "labelName": "Live-Windows",
-      "buildVersion": "++Fortnite+Release-25.00-CL-25909622-Windows",
-      "hash": "78cf23202befa88d526de0c8513fe12593f698a9",
+      "buildVersion": "++Fortnite+Release-41.00-CL-54618515-Windows",
+      "hash": "b129378b03c7a85f5633b41ad5467d851ba8e86c",
       "useSignedUrl": false,
       "metadata": {
-        "installationPoolId": "FortniteInstallationPool"
+        "installationPoolId": "FortniteInstallationPool",
+        "hasDependencyConfig": true
       },
       "manifests": [
         {
-          "uri": "https://fastly-download.epicgames.com/Builds/Fortnite/CloudDir/aR-p-XE-qiz2uidz3k636UNRwJ-eyg.manifest",
+          "uri": "https://egs-cloudfront-chunks.epicgamescdn.com/Builds/Fortnite/CloudDir/UcaaeP2Bi8ObrwuT60SrYiVf3NGxXA.manifest",
           "queryParams": [
             {
-              "name": "f_token",
-              "value": "1686504874_9bfccefe1826c0ee223e154c62c0a54e9dbccc13"
+              "name": "cf_token",
+              "value": "1780723395_70f97c1833b3e36042a9282e61a8b0a4d65e895c"
             }
           ]
         }
-      ]
+      ],
+      "selectiveDownload": [
+        {
+          "uri": "https://selective-download-egs.distro.on.epicgames.com/Org/o-aa83a0a9bc45e98c80c1b1c9d92e9e/Product/prod-fn/da/da1703a0b71dec81b397e187559a5f0dfc2774f19f7f665cee8512657511ccd8.sdmeta",
+          "queryParams": [
+            {
+              "name": "cf_token",
+              "value": "1780723395_612a0aa15358699157c96e2f9ffc5e7ed0246157"
+            }
+          ]
+        }
+      ],
+      "isPreloaded": false
     }
   ]
 }

--- a/EpicGames/LauncherService/Assets/V2/GetItemBuildSimple.md
+++ b/EpicGames/LauncherService/Assets/V2/GetItemBuildSimple.md
@@ -7,7 +7,6 @@ Auth Required: Yes (`launcher:download:{label}:{appName} READ`)
 ## Path Parameters
 
 `platform`: See [Platforms](../../README.md#data) <br/>
-`namespace`: The Catalog Namespace, e.g. `fn` for Fortnite <br/>
 `catalogItemId`: The Catalog-Item Id, e.g. `4fe75bbc5a674f4f9b356b5c90567da5` for Fortnite <br/>
 `appName`: The App Name (from Catalog Item), e.g. `Fortnite` for Fortnite
 
@@ -25,23 +24,36 @@ _Example Response (shortened)_
     {
       "appName": "Fortnite",
       "labelName": "Live-Windows",
-      "buildVersion": "++Fortnite+Release-25.00-CL-25909622-Windows",
-      "hash": "78cf23202befa88d526de0c8513fe12593f698a9",
+      "buildVersion": "++Fortnite+Release-41.00-CL-54618515-Windows",
+      "hash": "b129378b03c7a85f5633b41ad5467d851ba8e86c",
       "useSignedUrl": false,
       "metadata": {
-        "installationPoolId": "FortniteInstallationPool"
+        "installationPoolId": "FortniteInstallationPool",
+        "hasDependencyConfig": true
       },
       "manifests": [
         {
-          "uri": "https://epicgames-download1.akamaized.net/Builds/Fortnite/CloudDir/aR-p-XE-qiz2uidz3k636UNRwJ-eyg.manifest",
+          "uri": "https://egs-cloudfront-chunks.epicgamescdn.com/Builds/Fortnite/CloudDir/UcaaeP2Bi8ObrwuT60SrYiVf3NGxXA.manifest",
           "queryParams": [
             {
-              "name": "ak_token",
-              "value": "exp=1686513741~hmac=41d877f36622f4527fb9b3b7a8baaa6fef95ee7cb68650964c2b5db7cd9aab15"
+              "name": "cf_token",
+              "value": "1780723395_70f97c1833b3e36042a9282e61a8b0a4d65e895c"
             }
           ]
         }
-      ]
+      ],
+      "selectiveDownload": [
+        {
+          "uri": "https://selective-download-egs.distro.on.epicgames.com/Org/o-aa83a0a9bc45e98c80c1b1c9d92e9e/Product/prod-fn/da/da1703a0b71dec81b397e187559a5f0dfc2774f19f7f665cee8512657511ccd8.sdmeta",
+          "queryParams": [
+            {
+              "name": "cf_token",
+              "value": "1780723395_612a0aa15358699157c96e2f9ffc5e7ed0246157"
+            }
+          ]
+        }
+      ],
+      "isPreloaded": false
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

- [x] I have properly named the PR
- [x] I have described why this change should be merged (why is this change useful/good)
- [x] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Change Description

selectiveDownload currently contains some plain text data on the current manifest.
[da1703a0b71dec81b397e187559a5f0dfc2774f19f7f665cee8512657511ccd8.txt](https://github.com/user-attachments/files/28660125/da1703a0b71dec81b397e187559a5f0dfc2774f19f7f665cee8512657511ccd8.txt)

Also, GetItemBuildSimple does not have a namespace path parameter.