### PR TITLE
Add externalAuth to account creation payload

### DIFF
--- a/EpicGames/AccountService/Account/CreateAccount.md
+++ b/EpicGames/AccountService/Account/CreateAccount.md
@@ -14,7 +14,12 @@ Auth Required: Yes (`account:public:account CREATE`)
   "company": "Lele Exploits",
   "email": "lele@exmaple.com",
   "password": "hey123!",
-  "dateOfBirth": "2000-12-24"
+  "dateOfBirth": "2000-12-24",
+  "externalAuth": {
+    "authType": "google",
+    "externalAuthToken": "_"
+  },
+  "country": "DE"
 }
 ```
 
@@ -35,6 +40,7 @@ Auth Required: Yes (`account:public:account CREATE`)
 `email`: Optional, Your Email <br/>
 `username`: Optional, Your Username (could be used instead of an email back then) <br/>
 `password`: Optional, Your Password (required if email/username is specified) <br/>
+`externalAuth`: Optional, Payload of [External Auth Create](./ExternalAuth/Create.md#body) <br/>
 `dateOfBirth`: required, Your BirthDate
 
 ---

--- a/EpicGames/AccountService/Account/CreateAccount.md
+++ b/EpicGames/AccountService/Account/CreateAccount.md
@@ -6,6 +6,7 @@ Auth Required: Yes (`account:public:account CREATE`)
 
 ```json
 {
+  "dateOfBirth": "2000-12-24",
   "name": "_",
   "lastName": "_",
   "preferredLanguage": "de",
@@ -15,7 +16,6 @@ Auth Required: Yes (`account:public:account CREATE`)
   "company": "Lele Exploits",
   "email": "lele@exmaple.com",
   "password": "hey123!",
-  "dateOfBirth": "2000-12-24",
   "externalAuth": {
     "authType": "google",
     "externalAuthToken": "_"
@@ -31,6 +31,8 @@ Auth Required: Yes (`account:public:account CREATE`)
 
 ## Parameters
 
+
+`dateOfBirth`: Required, Your BirthDate <br/>
 `name`: Optional, Your Firstname <br/>
 `lastName`: Optional, Your Lastname <br/>
 `preferredLanguage`: Optional, Your new Preferred Language <br/>
@@ -41,8 +43,7 @@ Auth Required: Yes (`account:public:account CREATE`)
 `email`: Optional, Your Email <br/>
 `username`: Optional, Your Username (could be used instead of an email back then) <br/>
 `password`: Optional, Your Password (required if email/username is specified) <br/>
-`externalAuth`: Optional, Payload of [External Auth Create](./ExternalAuth/Create.md#body) <br/>
-`dateOfBirth`: required, Your BirthDate
+`externalAuth`: Optional, Payload of [External Auth Create](./ExternalAuth/Create.md#body)
 
 ---
 

--- a/EpicGames/AccountService/Account/CreateAccount.md
+++ b/EpicGames/AccountService/Account/CreateAccount.md
@@ -9,6 +9,7 @@ Auth Required: Yes (`account:public:account CREATE`)
   "name": "_",
   "lastName": "_",
   "preferredLanguage": "de",
+  "country": "DE",
   "displayName": "lele test",
   "phoneNumber": "0123456789",
   "company": "Lele Exploits",
@@ -18,8 +19,7 @@ Auth Required: Yes (`account:public:account CREATE`)
   "externalAuth": {
     "authType": "google",
     "externalAuthToken": "_"
-  },
-  "country": "DE"
+  }
 }
 ```
 
@@ -34,6 +34,7 @@ Auth Required: Yes (`account:public:account CREATE`)
 `name`: Optional, Your Firstname <br/>
 `lastName`: Optional, Your Lastname <br/>
 `preferredLanguage`: Optional, Your new Preferred Language <br/>
+`country`: Optional, Your Country Code <br/>
 `displayName`: Optional, Your Display Name <br/>
 `phoneNumber`: Optional, Your Phone-Number <br/>
 `company`: Optional, Your Company <br/>


### PR DESCRIPTION
## PR Checklist

- [x] I have properly named the PR
- [x] I have described why this change should be merged (why is this change useful/good)
- [x] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Change Description

Add documentation for usage of externalAuth in account creation. Typically this is utilized to create headless accounts.