### PR TITLE
Update giftWrapTemplateId format to be valid

### DIFF
--- a/EpicGames/FN-Service/Game/Profile/Operations/GiftCatalogEntry.md
+++ b/EpicGames/FN-Service/Game/Profile/Operations/GiftCatalogEntry.md
@@ -13,7 +13,7 @@
     "expectedTotalPrice": 0, // Calculate yourself or let epic calc it (using their endpoint)
     "gameContext": "Frontend.CatabaScreen", // Leave or Empty String
     "receiverAccountIds": [], // Friends Account Ids
-    "giftWrapTemplateId": "", // Empty String or GiftBox:GB_GiftWrap1 (1-4)
+    "giftWrapTemplateId": "", // Empty String or GiftBox:gb_giftwrap1 (1-4)
     "personalMessage": "" // Not used anymore (also doesnt show ingame anymore since v23.00)
 }
 ```


### PR DESCRIPTION
Change gift wrap ID to lowercase to be valid

## PR Checklist

- [x] I have properly named the PR
- [x] I have described why this change should be merged (why is this change useful/good)
- [x] I have followed the [Contribution Guide / Formatting](https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/blob/main/CONTRIBUTING.md)

## Change Description

The original ID provided was not valid and would cause an error. I would like "GB_GiftWrap1" to be lowercase so it does not return an error when used. Using for example 'GiftBox:gb_giftwrap1' is valid.

Example response of error:
`{'target': 'FRIEND_DISPLAY_NAME_HERE', 'offer_id': 'OFFER_ID_HERE', 'friend_id': 'FRIEND_ID_HERE', 'gift_result': {'friend_id': 'FRIEND_ID_HERE', 'offer_id': 'OFFER_ID_HERE', 'eligibility': {'price': {'currencyType': 'MtxCurrency', 'currencySubType': '', 'regularPrice': 800, 'dynamicRegularPrice': 800, 'finalPrice': 800, 'saleExpiration': '9999-12-31T23:59:59.999Z', 'basePrice': 800}, 'items': [{'templateId': 'CosmeticShoes:shoes_ironicsorbet', 'quantity': 1}], 'ownership': []}, 'gift_result': {'offer_id': 'OFFER_ID_HERE', 'receiver_account_id': 'FRIEND_ID_HERE', 'success': False, 'error': 'Code: "errors.com.epicgames.modules.gamesubcatalog.invalid_parameter" - Gift wrap template GiftBox:GB_GiftWrap2 is not valid.'}}}`